### PR TITLE
[ModalSheet] Add data based ModalSheet for dynamic content

### DIFF
--- a/demo/src/main/kotlin/eu/wewox/modalsheet/Example.kt
+++ b/demo/src/main/kotlin/eu/wewox/modalsheet/Example.kt
@@ -18,6 +18,10 @@ enum class Example(
         "Sheet Above Bottom Bar",
         "Showcases the fact, that modal is displayed above bottom bar"
     ),
+    DynamicModalSheet(
+        "Dynamic Content Modal Sheet",
+        "Example of modal sheet with dynamic content"
+    ),
     ScrollableModalSheet(
         "Scrollable Modal Sheet",
         "Example of scrollable modal sheet"

--- a/demo/src/main/kotlin/eu/wewox/modalsheet/MainActivity.kt
+++ b/demo/src/main/kotlin/eu/wewox/modalsheet/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import eu.wewox.modalsheet.screens.CustomFullScreenPopupScreen
 import eu.wewox.modalsheet.screens.CustomModalSheetScreen
+import eu.wewox.modalsheet.screens.DynamicModalSheetScreen
 import eu.wewox.modalsheet.screens.ScrollableModalSheetScreen
 import eu.wewox.modalsheet.screens.SheetAboveBottomBarScreen
 import eu.wewox.modalsheet.screens.SimpleModalSheetScreen
@@ -58,6 +59,7 @@ class MainActivity : ComponentActivity() {
                         null -> RootScreen(onExampleClick = { example = it })
                         Example.SimpleModalSheet -> SimpleModalSheetScreen()
                         Example.SheetAboveBottomBar -> SheetAboveBottomBarScreen()
+                        Example.DynamicModalSheet -> DynamicModalSheetScreen()
                         Example.ScrollableModalSheet -> ScrollableModalSheetScreen()
                         Example.CustomModalSheet -> CustomModalSheetScreen()
                         Example.CustomFullScreenPopup -> CustomFullScreenPopupScreen()

--- a/demo/src/main/kotlin/eu/wewox/modalsheet/screens/DynamicModalSheetScreen.kt
+++ b/demo/src/main/kotlin/eu/wewox/modalsheet/screens/DynamicModalSheetScreen.kt
@@ -1,0 +1,113 @@
+package eu.wewox.modalsheet.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import eu.wewox.modalsheet.Example
+import eu.wewox.modalsheet.ModalSheet
+import eu.wewox.modalsheet.ui.components.TopBar
+import eu.wewox.modalsheet.ui.theme.SpacingMedium
+import eu.wewox.modalsheet.ui.theme.SpacingSmall
+
+/**
+ * Showcases the use-case when modal sheet content is dynamic.
+ * For example an error modal which should be shown when error is not null.
+ */
+@Composable
+fun DynamicModalSheetScreen() {
+    Scaffold(
+        topBar = { TopBar(Example.DynamicModalSheet.label) }
+    ) { padding ->
+        var error by rememberSaveable(saver = ErrorDataSaver) { mutableStateOf(null) }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            Button(onClick = {
+                error = ErrorData(
+                    title = "Error",
+                    message = LoremIpsum
+                )
+            }) {
+                Text(text = "Make an error")
+            }
+        }
+
+        ErrorModalSheet(
+            error = error,
+            onDismiss = { error = null }
+        )
+    }
+}
+
+@Composable
+private fun ErrorModalSheet(
+    error: ErrorData?,
+    onDismiss: () -> Unit,
+) {
+    ModalSheet(
+        data = error,
+        visible = { this != null },
+        onDismiss = onDismiss
+    ) { data ->
+        if (data == null) {
+            return@ModalSheet
+        }
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(SpacingSmall),
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(SpacingMedium)
+        ) {
+            Text(
+                text = data.title,
+                style = MaterialTheme.typography.h4
+            )
+            Text(
+                text = data.message,
+            )
+        }
+    }
+}
+
+private data class ErrorData(val title: String, val message: String)
+
+private val ErrorDataSaver: Saver<MutableState<ErrorData?>, Any> = listSaver(
+    save = { listOf(it.value?.title, it.value?.message) },
+    restore = {
+        val title = it[0]
+        val message = it[1]
+        mutableStateOf(if (title != null && message != null) ErrorData(title, message) else null)
+    }
+)
+
+private val LoremIpsum = """
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Mauris dictum facilisis augue. 
+    Vivamus porttitor turpis ac leo. Quisque porta. Nulla pulvinar eleifend sem. Maecenas sollicitudin. 
+    Morbi imperdiet, mauris ac auctor dictum, nisl ligula egestas nulla, et sollicitudin sem purus in lacus. 
+    Phasellus rhoncus. Nulla quis diam. Ut tempus purus at lorem. Vestibulum fermentum tortor id mi.  
+    Nullam feugiat, turpis at pulvinar vulputate, erat libero tristique tellus, nec bibendum odio risus sit amet ante.
+""".trimIndent()

--- a/demo/src/main/kotlin/eu/wewox/modalsheet/screens/DynamicModalSheetScreen.kt
+++ b/demo/src/main/kotlin/eu/wewox/modalsheet/screens/DynamicModalSheetScreen.kt
@@ -68,12 +68,8 @@ private fun ErrorModalSheet(
 ) {
     ModalSheet(
         data = error,
-        visible = { this != null },
         onDismiss = onDismiss
     ) { data ->
-        if (data == null) {
-            return@ModalSheet
-        }
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(SpacingSmall),

--- a/modalsheet/src/main/java/eu/wewox/modalsheet/ModalSheet.kt
+++ b/modalsheet/src/main/java/eu/wewox/modalsheet/ModalSheet.kt
@@ -44,7 +44,8 @@ import eu.wewox.modalsheet.ModalSheetDefaults.Scrim
 import kotlin.math.roundToInt
 
 /**
- * Modal sheet that behaves like bottom sheet and draws over system UI.
+ * Static modal sheet that behaves like bottom sheet and draws over system UI.
+ * Non-data variant should contain only static [content]. For dynamic content use [ModalSheet].
  *
  * @param visible True if modal should be visible.
  * @param onDismiss Called when user touches the scrim or swipes the sheet away.
@@ -68,15 +69,61 @@ fun ModalSheet(
     },
     content: @Composable ModalSheetScope.() -> Unit,
 ) {
+    ModalSheet(
+        data = Unit,
+        visible = { visible },
+        onDismiss = onDismiss,
+        shape = shape,
+        backgroundColor = backgroundColor,
+        swipeEnabled = swipeEnabled,
+        scrimClickEnabled = scrimClickEnabled,
+        scrim = scrim,
+        content = { content() }
+    )
+}
+
+/**
+ * Modal sheet that behaves like bottom sheet and draws over system UI.
+ *
+ * @param data The data to show in the content.
+ * @param visible Called to check if modal should be show for the given data.
+ * @param onDismiss Called when user touches the scrim or swipes the sheet away.
+ * @param shape Defines the modal's shape
+ * @param backgroundColor The background color. Use Color.Transparent to have no color.
+ * @param swipeEnabled True if swipe interaction with bottom sheet is enabled.
+ * @param scrimClickEnabled True if click on scrim is enabled.
+ * @param scrim Optional custom scrim.
+ * @param content The content of the bottom sheet.
+ */
+@Composable
+fun <T> ModalSheet(
+    data: T?,
+    visible: T?.() -> Boolean,
+    onDismiss: () -> Unit,
+    shape: Shape = MaterialTheme.shapes.large.copy(bottomEnd = CornerSize(0), bottomStart = CornerSize(0)),
+    backgroundColor: Color = MaterialTheme.colors.surface,
+    swipeEnabled: Boolean = true,
+    scrimClickEnabled: Boolean = true,
+    scrim: @Composable BoxScope.(Boolean) -> Unit = {
+        Scrim(it, onScrimClick = if (scrimClickEnabled) onDismiss else NoOpLambda)
+    },
+    content: @Composable ModalSheetScope.(T?) -> Unit,
+) {
+    var contentData by remember { mutableStateOf(data) }
+    val modalVisible = data.visible()
+    if (modalVisible) {
+        contentData = data
+    }
+
     // If content animated by AnimatedVisibility in PopupBody is still visible (in composition)
     var contentVisible by remember { mutableStateOf(false) }
 
-    if (visible || contentVisible) {
+    if (modalVisible || contentVisible) {
         FullScreenPopup(
             onDismiss = onDismiss
         ) {
             PopupBody(
-                visible = visible,
+                visible = modalVisible,
                 scrim = scrim,
                 content = {
                     // Set contentVisible true when the composable enters composition and false when it leaves
@@ -96,7 +143,7 @@ fun ModalSheet(
                             color = backgroundColor,
                             modifier = Modifier.fillMaxWidth()
                         ) {
-                            scope.content()
+                            scope.content(contentData)
                         }
                     }
                 }


### PR DESCRIPTION
Should fix #1 

Do not really like the API though :/ 

@wooodenleg What do you think?

```
ModalSheet(
    data = error,
    visible = { this != null },
    onDismiss = onDismiss
) { data ->
    if (data == null) {
        return@ModalSheet
    }
    // Use `data` for content
}
```

https://user-images.githubusercontent.com/20944869/167252435-6a31b477-d1a1-40bb-b6fb-9c14f65aee05.mp4


